### PR TITLE
以 minidump 为 main, 看看 logical plan toJson 的输出是否满足咱们要求

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/Minidump.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/Minidump.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.qe.SessionVariable;
@@ -128,6 +129,13 @@ public class Minidump {
 
     /** Nereids minidump entry, argument should be absolute address of minidump path */
     public static void main(String[] args) {
+        NereidsParser nereidsParser_ = new NereidsParser();
+        LogicalPlan parsed_ = nereidsParser_.parseSingle("select a from t as t1 join t2 on t1.a=t2.a and t1.c=t1.d;");
+        String result = ((AbstractPlan) parsed_).toJson().toString(2);
+        System.out.println(result);
+        System.out.println(parsed_.treeString());
+        System.exit(0);
+
         assert (args.length == 1);
         Minidump minidump = null;
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -221,6 +221,7 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
 
     @Override
     public JSONObject toJson() {
+        System.out.println("LogicalProject.toJson()");
         JSONObject logicalProject = super.toJson();
         JSONObject properties = new JSONObject();
         properties.put("Projects", projects.toString());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.json.JSONObject;
+
 /**
  * The node of logical plan for sub query and alias
  *
@@ -124,6 +126,15 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
         return Utils.toSqlString("LogicalSubQueryAlias",
                 "qualifier", qualifier
         );
+    }
+
+    @Override
+    public JSONObject toJson() {
+        JSONObject logicalRelation = super.toJson();
+        JSONObject properties = new JSONObject();
+        properties.put("Qualifier", qualifier.toString());
+        logicalRelation.put("Properties", properties);
+        return logicalRelation;
     }
 
     @Override


### PR DESCRIPTION
探索的初始目的
1. 看看怎样从执行计划中找到别名的关系。
2. sqlglot 的执行计划和 doris 执行计划区别是否大？

经过这个 PR 的探索，有几个发现
1. 只需要逻辑执行计划，即可找到别名和实际名字的关系，而不是物理执行计划。
2. doris 可以将执行计划输出为哪些形式？
   1. 通过运行 `explain parsed plan {query}`，可以看到 doris 对一条 sql 的逻辑执行计划的文本版，类似
       ![image](https://github.com/cosven/doris/assets/4962134/0379b496-1ac1-4dd4-8f4e-c1a46dda2d72)
   2. doris 目前也支持输出一个逻辑执行计划的 json 版本，但不完善。比如这个 PR 里面为 LogicalSubQueryAlias 加了个 toJson 的方法。

另外有几个感受
1. 逻辑执行计划并没有特别复杂，看代码可以发现 LogicalXxx 的结构都比较简单。
2. 感觉大概率直接用 sqlglot 的执行计划就行了。


